### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Run Extension Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TheArqsz/JSRecon-Buddy/security/code-scanning/1](https://github.com/TheArqsz/JSRecon-Buddy/security/code-scanning/1)

In general, the fix is to declare an explicit `permissions` block that grants only the minimal required scopes to `GITHUB_TOKEN`. For a CI workflow that only checks out code, installs dependencies, and runs tests, read-only access to repository contents is sufficient.

The best single fix with no behavior change is to add a `permissions` block at the workflow root level (so it applies to all jobs) with `contents: read`. This documents the workflow’s needs and ensures the token is not granted unnecessary write permissions. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Run Extension Tests` (line 1) and the `on:` block (line 3). No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
